### PR TITLE
Sitecore 9.3 compatibility

### DIFF
--- a/EPExpressTab/Pipelines/Initialize/Initialize.cs
+++ b/EPExpressTab/Pipelines/Initialize/Initialize.cs
@@ -12,6 +12,7 @@ using EPExpressTab.Handlers;
 using Sitecore;
 using Sitecore.Configuration;
 using Sitecore.Data;
+using Sitecore.Data.Events;
 using Sitecore.Data.Items;
 using Sitecore.Pipelines;
 using Sitecore.SecurityModel;
@@ -29,7 +30,9 @@ namespace EPExpressTab.Pipelines.Initialize
 			if (core == null)
 				return;
 			EpContext.Tabs = AppDomain.CurrentDomain.GetAssemblies().Where(x => !Constants.BinaryBlacklist.Contains(x.GetName().Name)).SelectMany(GetEpTabs).Select(t => (EpExpressModel)Activator.CreateInstance(t)).ToDictionary(x => x.GetType().AssemblyQualifiedName);
-			using (new SecurityDisabler())
+			
+            using (new EventDisabler())
+            using (new SecurityDisabler())
 			{
 				Item tabs = core.GetItem(Constants.EpTabsFolder);
 				Item rendering = core.GetItem(Constants.EpExpressRendering);


### PR DESCRIPTION
Hi @JeffDarchuk ,

Sitecore 9.3 introduces an extra event handler that listens for item:saved events. This event handler calls `Sitecore.Context.PageMode.IsExperienceEditor` which executes `return Context.Site.DisplayMode == DisplayMode.Edit;`. This statement crashes within the Initialize pipeline, because a Site has not yet been set in the context. 

I've added the `EventDisabler` to work around this issue, and during my testing i have not noticed any implications, and as far as i know the events that are caused by the Save are not required for EPExpressTab to function properly.  

If the events are required, we could also change the `EventDisabler` to a ` SiteContextSwitcher(SiteContext.GetSite("shell"))`, however i prefer disabling the events.